### PR TITLE
Code editor takes full screen when collab is off 

### DIFF
--- a/development/src/app/page.js
+++ b/development/src/app/page.js
@@ -10,8 +10,7 @@ import { useTabContext } from '@/composables/tabContext';
 import CodingEditor from '@/components/codingEditor';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import runIcon from '../../public/assets/languageIcons/runIcon.svg';
-import Image from 'next/image';
+import Collab from '@/components/collab_comp';
 
 function Home() {
   const { items, setItems } = useTabContext();
@@ -146,7 +145,7 @@ function Home() {
                 <Welcome />
               </div>
             ) : items.filter((e) => e.active)[0] ? (
-              <CodingEditor language={items.filter((e) => e.active)[0].ext} />
+              <Collab />
             ) : (
               <div className="p-11">
                 <Welcome />

--- a/development/src/app/page.js
+++ b/development/src/app/page.js
@@ -7,7 +7,6 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { Modal } from '@/components/modal';
 import { LanguageModal } from '@/components/languageModal_comp';
 import { useTabContext } from '@/composables/tabContext';
-import CodingEditor from '@/components/codingEditor';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Collab from '@/components/collab_comp';

--- a/development/src/components/codingEditor.js
+++ b/development/src/components/codingEditor.js
@@ -2,9 +2,12 @@
 import { useState } from 'react';
 import MonacoEditor from 'react-monaco-editor/lib/editor';
 import { useTheme } from 'next-themes';
+import { useTabContext } from '@/composables/tabContext';
 
-function CodingEditor({ language }) {
+function CodingEditor() {
   const { theme, setTheme } = useTheme();
+  const { items } = useTabContext();
+  const language = items.filter((e) => e.active)[0].ext;
   const [code, setCode] = useState(
     '// Welcome to P2P Coder, a Community Prepared Platform...'
   );
@@ -17,12 +20,12 @@ function CodingEditor({ language }) {
 
   const options = {
     selectOnLineNumbers: true,
+    automaticLayout: true,
   };
   return (
     <div>
       <MonacoEditor
-        width="91vw"
-        height="98vh"
+        height="95vh"
         language={
           language === '.js'
             ? 'javascript'

--- a/development/src/components/collab_comp.js
+++ b/development/src/components/collab_comp.js
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import CodingEditor from './codingEditor';
+
+const Collab = () => {
+  const [isVideoOn, setIsVideoOn] = useState(false);
+
+  return (
+    <div className="w-full flex">
+      <div className={`${isVideoOn ? 'w-2/3' : 'w-[95vw]'}`}>
+        <CodingEditor isVideoOn={isVideoOn} />
+      </div>
+      {isVideoOn && (
+        <div className="w-1/3">
+          <h1>Video Component here</h1>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Collab;


### PR DESCRIPTION
## Description of what this Pull Request does
- [x] Wraps code editor and future video component in a single component
- [x] Code editor takes the full width of the code screen when collab is off.

## Related Issue
#180 

## Recording
### Note:
 `toggleWidth` button was only added for recording purposes and removed before push


![collabSession](https://github.com/annonymousauthority/P2PCoder/assets/75104021/c810d47c-8196-4563-918c-02774189ffca)

